### PR TITLE
Adds support for optimistic concurrency

### DIFF
--- a/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
+++ b/ScriptBuilder/Saga/Writers/MsSqlServerSagaScriptWriter.cs
@@ -159,7 +159,8 @@ set @createTable = '
         OriginalMessageId nvarchar(255),
         Data nvarchar(max) not null,
         PersistenceVersion varchar(23) not null,
-        SagaTypeVersion varchar(23) not null
+        SagaTypeVersion varchar(23) not null,
+        SagaVersion int not null
     )
 ';
 exec(@createTable);
@@ -181,9 +182,9 @@ if exists
         and type in ('U')
 )
 begin
-    declare @createTable nvarchar(max);
-    set @createTable = 'drop table  if exists ' + @tableName;
-    exec(@createTable);
+    declare @dropTable nvarchar(max);
+    set @dropTable = 'drop table ' + @tableName;
+    exec(@dropTable);
 end
 ");
     }

--- a/ScriptBuilder/Saga/Writers/MySqlSagaScriptWriter.cs
+++ b/ScriptBuilder/Saga/Writers/MySqlSagaScriptWriter.cs
@@ -176,6 +176,7 @@ set @createTable = concat('
         Data longtext not null,
         PersistenceVersion varchar(23) not null,
         SagaTypeVersion varchar(23) not null,
+        SagaVersion int not null,
         primary key (`Id`)
     ) DEFAULT CHARSET=utf8;
 ');

--- a/SqlPersistence.Tests/Integration/SqlQueueDeletion.cs
+++ b/SqlPersistence.Tests/Integration/SqlQueueDeletion.cs
@@ -7,7 +7,7 @@ static class SqlQueueDeletion
     {
         var deleteScript = $@"
                     if exists (SELECT * from sys.objects where object_id = object_id(N'{schema}.{queueName}') and type in (N'U'))
-                    drop table {schema}.{queueName}";
+                    drop table [{schema}].[{queueName}]";
         using (var command = connection.CreateCommand())
         {
             command.CommandText = deleteScript;

--- a/SqlPersistence.Tests/Saga/SagaPersisterTests.UpdateWithCorrectVersion.approved.txt
+++ b/SqlPersistence.Tests/Saga/SagaPersisterTests.UpdateWithCorrectVersion.approved.txt
@@ -1,0 +1,11 @@
+﻿{
+  "Data": {
+    "CorrelationProperty": "theCorrelationProperty",
+    "TransitionalCorrelationProperty": "theTransitionalCorrelationProperty",
+    "SimpleProperty": "UpdatedValue",
+    "Id": "theSagaId",
+    "Originator": "theOriginator",
+    "OriginalMessageId": "theOriginalMessageId"
+  },
+  "Version": 2
+}


### PR DESCRIPTION
BTW, I think we should implement the pessimistic locking eventually. But this one is good for start. I haven't run the MySQL version but it should be fine as it uses plain old `int` column and does the incrementing when saving.

The version is stored in the context bag which makes it hard to use custom finders. Basically a custom finder needs to set this the version value for the returned saga. It is even more tricky since custom finders don't have access to writable context and need to downcast.

An alternative would be to add a field in `IContainSagaData` derived class but it feels wrong to me. The version should be handled internally and not exposed on the saga data.