### PR TITLE
Switching to sequential access for outbox, saga and timeout persister

### DIFF
--- a/SqlPersistence/Saga/RuntimeSagaInfo.cs
+++ b/SqlPersistence/Saga/RuntimeSagaInfo.cs
@@ -97,10 +97,11 @@ class RuntimeSagaInfo
     }
 
 
-    public TSagaData FromString<TSagaData>(TextReader reader, Version storedSagaTypeVersion)
+    public TSagaData FromString<TSagaData>(Stream stream, Version storedSagaTypeVersion)
         where TSagaData : IContainSagaData
     {
         var serializer = GetDeserialize(storedSagaTypeVersion);
+        using(var reader = new StreamReader(stream))
         using (var jsonReader = readerCreator(reader))
         {
             return serializer.Deserialize<TSagaData>(jsonReader);

--- a/SqlPersistence/Serializer.cs
+++ b/SqlPersistence/Serializer.cs
@@ -17,9 +17,10 @@ static class Serializer
         JsonSerializer = JsonSerializer.Create(settings);
     }
 
-    public static T Deserialize<T>(TextReader textReader)
+    public static T Deserialize<T>(Stream stream)
     {
-        using (var jsonReader = new JsonTextReader(textReader))
+        using(var reader = new StreamReader(stream))
+        using (var jsonReader = new JsonTextReader(reader))
         {
             return JsonSerializer.Deserialize<T>(jsonReader);
         }


### PR DESCRIPTION
Haven't had a chance to thoroughly test it. We applied the same for Sql Server [in this PR
](https://github.com/Particular/NServiceBus.SqlServer/pull/211)

More information see

https://msdn.microsoft.com/en-us/library/hh556234.aspx

and

https://stackify.com/improved-performance-using-json-streaming/
